### PR TITLE
Add support for arithmetic multiplication sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ let result = exactMath.add('3.00000000000000000015', '12.00000000000000020020', 
   * `1.5`, `0.5` or `.5` decimal fractions
   * `-5`, `-.4`, `-5.55` negative values
   * `2e-2`, `.25e+12`, `-3e-10` exponential notation values
-  * `*` multiplication sign *(also `x` and `⋅` [see [config.mulChar](#mulchar)])*
+  * `*` multiplication sign *(also `x`, `×` and `⋅` [see [config.mulChar](#mulchar)])*
   * `/` division sign *(also `:` and `÷` [see [config.divChar](#divchar)])*
   * `+` plus sign
   * `-` subtraction sign
@@ -281,14 +281,14 @@ The **[String]** numerical values passed as the arguments and the **[String]** r
 
 #### `mulChar`
 **Type:** [String|Array:string]  
-**Default:** `['*', 'x', '⋅']`
+**Default:** `['*', 'x', '×', '⋅']`
 * it applies only for [String] **formulas** in the [`formula`](#formula) method
 * in javaScript, the multiplication operation requires the `*` character, while out-of-coding notations sometimes also allows `x` or `⋅` dot operator *(unicode: `'\u22C5'`)* character
 * this setting lets to choose which characters are allowed for [`formula`](#formula) multiplication operations *(the characters other than `*`, `x` and `⋅` will be ignored)*. The default value will be used, if the illegal value has been passed
-* the legal `mulChar` settings samples: `'*'`, `'x'`, `'⋅'`, `['*', 'x', '⋅']`, `['*']`, `['x']`, `['*', '⋅']` etc.
-* by **default**, the [String] formula may contain `*`, `x` and `⋅` for multiplication operations, eg: `'5 * 4'`, `4x2`, `'4.5 * (3x.2)*3'`, `'3 ⋅ 3 \ 2'`
-* in order to allow **only** `*` character (and thereby forbid `x` and `⋅` character), set `mulChar` property to [String] `*` or [Array] `['*']`
-* it may turn out handy especially for the end-users that will fill the inputs with some multiplication math formulas, that will be further passed through the `exact-math`.`formula` method to calculate some result. The `x` or `⋅` usage would not throw an error then
+* the legal `mulChar` settings samples: `'*'`, `'x'`, `'×'`, `'⋅'`, `['*', 'x', '×', '⋅']`, `['*']`, `['x']`, `['*', '⋅']` etc.
+* by **default**, the [String] formula may contain `*`, `x`, `×` and `⋅` for multiplication operations, eg: `'5 * 4'`, `4x2`, `3×6`, `'4.5 * (3x.2)*3'`, `'3 ⋅ 3 \ 2'`
+* in order to allow **only** `*` character (and thereby forbid `x`, `×` and `⋅` character), set `mulChar` property to [String] `*` or [Array] `['*']`
+* it may turn out handy especially for the end-users that will fill the inputs with some multiplication math formulas, that will be further passed through the `exact-math`.`formula` method to calculate some result. The `x`, `×` or `⋅` usage would not throw an error then
 * see the [\[samples\]](#the-config-mulchar-property-usage)
 
 #### `eMinus`
@@ -504,9 +504,9 @@ exactMath.formula('10÷2', { divChar: ['÷'] }); //5
 ##### The config `mulChar` property usage
 ```javascript
 const exactMath = require('exact-math');
-exactMath.formula('5*5 + 5x5 + 5⋅5'); //75
-exactMath.formula('5*5 + 5x5 + 5⋅5', { mulChar: ['*', 'x', '⋅'] }); //75
-exactMath.formula('5*5 + 5x5 + 5⋅5', { mulChar: ['x'] }); //[Error]: The [String] formula contains illegal character *
+exactMath.formula('5*5 + 5x5 + 5⋅5 + 5×5'); //100
+exactMath.formula('5*5 + 5x5 + 5⋅5 + 5×5', { mulChar: ['*', 'x', '⋅', '×'] }); //100
+exactMath.formula('5*5 + 5x5 + 5⋅5 + 5×5', { mulChar: ['x'] }); //[Error]: The [String] formula contains illegal character *
 exactMath.formula('5*5', { mulChar: '*' }); //25
 exactMath.formula('5*5 + 5⋅5', { mulChar: ['*', '⋅'] }); //50
 ```

--- a/src/exact-math.js
+++ b/src/exact-math.js
@@ -148,7 +148,7 @@ class _ExactMath {
     return {
       decimalChar: new Map([['.', true], [',', true]]),
       divChar: new Map([['/', true], [':', true], ['÷', true]]),
-      mulChar: new Map([['*', true], ['x', true], ['⋅', true]])
+      mulChar: new Map([['*', true], ['x', true], ['⋅', true], ['×', true]])
     };
   }
 

--- a/tests/config-mul-char.js
+++ b/tests/config-mul-char.js
@@ -13,32 +13,35 @@ describe('When the module is executed with formula method', function () {
   });
   describe('with the [Object] config object', function () {
     describe("that has not 'mulChar' property defined", function () {
-      it("the '*', 'x' and '⋅' characters should be allowed by default in formula", function () {
+      it("the '*', 'x', '×' and '⋅' characters should be allowed by default in formula", function () {
         this.asteriskAllowed([{}]);
         this.xAllowed([{}]);
         this.dotAllowed([{}]);
+        this.multiplySignAllowed([{}]);
       });
     });
     describe("that has 'mulChar' property defined", function () {
       describe('but of incorrect type', function () {
-        it("the '*', 'x' and '⋅' characters should be allowed by default in formula", function () {
+        it("the '*', 'x', '×' and '⋅' characters should be allowed by default in formula", function () {
           for (let type of this.incorrectTypes) {
             const config = { mulChar: type };
             this.asteriskAllowed([config]);
             this.xAllowed([config]);
             this.dotAllowed([config]);
+            this.multiplySignAllowed([config]);
           }
         });
       });
     });
     describe('of correct [String] type', function () {
       describe('that contains illegal character', function () {
-        it("the '*', 'x' and '⋅' characters should be allowed by default in formula", function () {
-          for (let value of ['a', '&', '!', '.,', 'x*', '$', '%', '^', '[]']) {
+        it("the '*', 'x', '×' and '⋅' characters should be allowed by default in formula", function () {
+          for (let value of ['a', '&', '!', '.,', 'x*×', '$', '%', '^', '[]']) {
             const config = { mulChar: value };
             this.asteriskAllowed([config]);
             this.xAllowed([config]);
             this.dotAllowed([config]);
+            this.multiplySignAllowed([config]);
           }
         });
       });
@@ -53,6 +56,9 @@ describe('When the module is executed with formula method', function () {
         it("the 'x' character should not be allowed in formula", function () {
           this.xForbidden([config]);
         });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
       });
       describe("that contains 'x' character", function () {
         const config = { mulChar: 'x' };
@@ -64,6 +70,9 @@ describe('When the module is executed with formula method', function () {
         });
         it("the '*' character should not be allowed in formula", function () {
           this.asteriskForbidden([config]);
+        });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
         });
       });
       describe("that contains '⋅' character", function () {
@@ -77,23 +86,43 @@ describe('When the module is executed with formula method', function () {
         it("the 'x' character should not be allowed in formula", function () {
           this.xForbidden([config]);
         });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
+      });
+      describe("that contains '×' character", function () {
+        const config = { mulChar: '×' };
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+        it("the '⋅' character should not be allowed in formula", function () {
+          this.dotForbidden([config]);
+        });
+        it("the '*' character should not be allowed in formula", function () {
+          this.asteriskForbidden([config]);
+        });
+        it("the 'x' character should not be allowed in formula", function () {
+          this.xForbidden([config]);
+        });
       });
     });
     describe('of correct [Array] type', function () {
       describe('that is empty', function () {
-        it("the '*', 'x' and '⋅' characters should be allowed by default in formula", function () {
+        it("the '*', 'x', '×' and '⋅' characters should be allowed by default in formula", function () {
           const config = { mulChar: [] };
           this.asteriskAllowed([config]);
           this.xAllowed([config]);
           this.dotAllowed([config]);
+          this.multiplySignAllowed([config]);
         });
       });
       describe('that contains only illegal character', function () {
-        it("the '*', 'x' and '⋅' characters should be allowed by default in formula", function () {
+        it("the '*', 'x', '×' and '⋅' characters should be allowed by default in formula", function () {
           const config = { mulChar: [1, true, 'hello', '10', '^', '$', '[', ')'] };
           this.asteriskAllowed([config]);
           this.xAllowed([config]);
           this.dotAllowed([config]);
+          this.multiplySignAllowed([config]);
         });
       });
       describe("that contains some illegal character but also '*' character", function () {
@@ -107,6 +136,9 @@ describe('When the module is executed with formula method', function () {
         it("the 'x' character should not be allowed in formula", function () {
           this.xForbidden([config]);
         });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
       });
       describe("that contains only '*' character", function () {
         const config = { mulChar: ['*'] };
@@ -118,6 +150,9 @@ describe('When the module is executed with formula method', function () {
         });
         it("the 'x' character should not be allowed in formula", function () {
           this.xForbidden([config]);
+        });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
         });
       });
       describe("that contains some illegal character but also 'x' character", function () {
@@ -131,6 +166,9 @@ describe('When the module is executed with formula method', function () {
         it("the '*' character should not be allowed in formula", function () {
           this.asteriskForbidden([config]);
         });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
       });
       describe("that contains only 'x' character", function () {
         const config = { mulChar: ['x'] };
@@ -142,6 +180,9 @@ describe('When the module is executed with formula method', function () {
         });
         it("the '*' character should not be allowed in formula", function () {
           this.asteriskForbidden([config]);
+        });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
         });
       });
       describe("that contains some illegal character but also '⋅' character", function () {
@@ -155,6 +196,9 @@ describe('When the module is executed with formula method', function () {
         it("the 'x' character should not be allowed in formula", function () {
           this.xForbidden([config]);
         });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
       });
       describe("that contains only '⋅' character", function () {
         const config = { mulChar: ['⋅'] };
@@ -167,9 +211,42 @@ describe('When the module is executed with formula method', function () {
         it("the 'x' character should not be allowed in formula", function () {
           this.xForbidden([config]);
         });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
       });
-      describe("that contains some illegal character but also '*', 'x' and '⋅' characters", function () {
-        const config = { mulChar: [1, true, '⋅', 'hello', '10', '^', 'x', '$', '[', '*', ')'] };
+      describe("that contains some illegal character but also '×' character", function () {
+        const config = { mulChar: [1, true, '×', 'hello', '10', '^', '$', '[', ')'] };
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+        it("the '*' character should not be allowed in formula", function () {
+          this.asteriskForbidden([config]);
+        });
+        it("the 'x' character should not be allowed in formula", function () {
+          this.xForbidden([config]);
+        });
+        it("the '⋅' character should not be allowed in formula", function () {
+          this.dotForbidden([config]);
+        });
+      });
+      describe("that contains only '×' character", function () {
+        const config = { mulChar: ['×'] };
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+        it("the '*' character should not be allowed in formula", function () {
+          this.asteriskForbidden([config]);
+        });
+        it("the 'x' character should not be allowed in formula", function () {
+          this.xForbidden([config]);
+        });
+        it("the '⋅' character should not be allowed in formula", function () {
+          this.dotForbidden([config]);
+        });
+      });
+      describe("that contains some illegal character but also '*', 'x', '×' and '⋅' characters", function () {
+        const config = { mulChar: [1, true, '⋅', 'hello', '10', '^', 'x', '×', '$', '[', '*', ')'] };
         it("the '*' character should be allowed in formula", function () {
           this.asteriskAllowed([config]);
         });
@@ -178,6 +255,9 @@ describe('When the module is executed with formula method', function () {
         });
         it("the 'x' character should be allowed in formula", function () {
           this.xAllowed([config]);
+        });
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
         });
       });
       describe("that contains '*', 'x' and '⋅' characters", function () {
@@ -191,7 +271,87 @@ describe('When the module is executed with formula method', function () {
         it("the 'x' character should be allowed in formula", function () {
           this.xAllowed([config]);
         });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
       });
+      describe("that contains '*', 'x', '×' and '⋅' characters", function () {
+        const config = { mulChar: ['*', 'x', '×', '⋅'] };
+        it("the '*' character should be allowed in formula", function () {
+          this.asteriskAllowed([config]);
+        });
+        it("the '⋅' character should be allowed in formula", function () {
+          this.dotAllowed([config]);
+        });
+        it("the 'x' character should be allowed in formula", function () {
+          this.xAllowed([config]);
+        });
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+      });
+
+      describe("that contains '*', 'x' and '⋅' characters", function () {
+        const config = { mulChar: ['*', 'x', '⋅'] };
+        it("the '*' character should be allowed in formula", function () {
+          this.asteriskAllowed([config]);
+        });
+        it("the '⋅' character should be allowed in formula", function () {
+          this.dotAllowed([config]);
+        });
+        it("the 'x' character should be allowed in formula", function () {
+          this.xAllowed([config]);
+        });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
+      });
+      describe("that contains '×', 'x' and '⋅' characters", function () {
+        const config = { mulChar: ['×', 'x', '⋅'] };
+        it("the '⋅' character should be allowed in formula", function () {
+          this.dotAllowed([config]);
+        });
+        it("the 'x' character should be allowed in formula", function () {
+          this.xAllowed([config]);
+        });
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+        it("the '*' character should not be allowed in formula", function () {
+          this.asteriskForbidden([config]);
+        });
+      });
+      describe("that contains '*', '×' and '⋅' characters", function () {
+        const config = { mulChar: ['*', '×', '⋅'] };
+        it("the '*' character should be allowed in formula", function () {
+          this.asteriskAllowed([config]);
+        });
+        it("the '⋅' character should be allowed in formula", function () {
+          this.dotAllowed([config]);
+        });
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+        it("the 'x' character should not be allowed in formula", function () {
+          this.xForbidden([config]);
+        });
+      });
+      describe("that contains '*', 'x' and '×' characters", function () {
+        const config = { mulChar: ['*', 'x', '×'] };
+        it("the '*' character should be allowed in formula", function () {
+          this.asteriskAllowed([config]);
+        });
+        it("the 'x' character should be allowed in formula", function () {
+          this.xAllowed([config]);
+        });
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+        it("the '⋅' character should not be allowed in formula", function () {
+          this.dotForbidden([config]);
+        });
+      });
+
       describe("that contains '*' and 'x' characters", function () {
         const config = { mulChar: ['*', 'x'] };
         it("the '*' character should be allowed in formula", function () {
@@ -202,6 +362,9 @@ describe('When the module is executed with formula method', function () {
         });
         it("the '⋅' character should not be allowed in formula", function () {
           this.dotForbidden([config]);
+        });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
         });
       });
       describe("that contains 'x' and '⋅' characters", function () {
@@ -215,6 +378,9 @@ describe('When the module is executed with formula method', function () {
         it("the '*' character should not be allowed in formula", function () {
           this.asteriskForbidden([config]);
         });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
       });
       describe("that contains '*' and '⋅' characters", function () {
         const config = { mulChar: ['*', '⋅'] };
@@ -227,7 +393,58 @@ describe('When the module is executed with formula method', function () {
         it("the 'x' character should not be allowed in formula", function () {
           this.xForbidden([config]);
         });
+        it("the '×' character should not be allowed in formula", function () {
+          this.multiplySignForbidden([config]);
+        });
       });
+      describe("that contains '*' and '×' characters", function () {
+        const config = { mulChar: ['*', '×'] };
+        it("the '*' character should be allowed in formula", function () {
+          this.asteriskAllowed([config]);
+        });
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+        it("the 'x' character should not be allowed in formula", function () {
+          this.xForbidden([config]);
+        });
+        it("the '⋅' character should not be allowed in formula", function () {
+          this.dotForbidden([config]);
+        });
+      });
+      describe("that contains '⋅' and '×' characters", function () {
+        const config = { mulChar: ['⋅', '×'] };
+        it("the '⋅' character should be allowed in formula", function () {
+          this.dotAllowed([config]);
+        });
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+        it("the 'x' character should not be allowed in formula", function () {
+          this.xForbidden([config]);
+        });
+        it("the '*' character should not be allowed in formula", function () {
+          this.asteriskForbidden([config]);
+        });
+      });
+      describe("that contains 'x' and '×' characters", function () {
+        const config = { mulChar: ['x', '×'] };
+        it("the 'x' character should be allowed in formula", function () {
+          this.xAllowed([config]);
+        });
+        it("the '×' character should be allowed in formula", function () {
+          this.multiplySignAllowed([config]);
+        });
+        it("the '*' character should not be allowed in formula", function () {
+          this.asteriskForbidden([config]);
+        });
+        it("the '⋅' character should not be allowed in formula", function () {
+          this.dotForbidden([config]);
+        });
+      });
+
+
+
     });
   });
 });

--- a/tests/helpers/chars-templates.js
+++ b/tests/helpers/chars-templates.js
@@ -100,6 +100,12 @@ beforeAll(function(){
     expect(this.exactMath.formula('5+((10-2) ⋅ 2)⋅.5', ...config)).toEqual(13);
   };
 
+  this.multiplySignAllowed = (config)=>{
+    expect(this.exactMath.formula('10 × 2', ...config)).toEqual(20);
+    expect(this.exactMath.formula('10(.5×.025)', ...config)).toEqual(0.125);
+    expect(this.exactMath.formula('5+((10-2) × 2)×.5', ...config)).toEqual(13);
+  };
+
   this.asteriskForbidden = (config)=>{
     expect(() => this.exactMath.formula('10 * 2', ...config)).toThrowError(this.incorrectFormula('*'));
     expect(() => this.exactMath.formula('10(.5*.025)', ...config)).toThrowError(this.incorrectFormula('*'));
@@ -116,6 +122,12 @@ beforeAll(function(){
     expect(() => this.exactMath.formula('10 ⋅ 2', ...config)).toThrowError(this.incorrectFormula('⋅'));
     expect(() => this.exactMath.formula('5+((10-2) ⋅ 2)⋅.5', ...config)).toThrowError(this.incorrectFormula('⋅'));
     expect(() => this.exactMath.formula('5+((10-2) ⋅ 2)⋅.5', ...config)).toThrowError(this.incorrectFormula('⋅'));
+  };
+
+  this.multiplySignForbidden = (config)=>{
+    expect(() => this.exactMath.formula('10 × 2', ...config)).toThrowError(this.incorrectFormula('×'));
+    expect(() => this.exactMath.formula('10(.5×.025)', ...config)).toThrowError(this.incorrectFormula('×'));
+    expect(() => this.exactMath.formula('5+((10-2) × 2)×.5', ...config)).toThrowError(this.incorrectFormula('×'));
   };
   
 });


### PR DESCRIPTION
As the division sign is already supported, it makes sense to support the cross-shaped multiplication sign.
This is the mathematical symbol, which is different from the lowercase X letter.
